### PR TITLE
gnl large filedescriptor test

### DIFF
--- a/get_next_line_tests/tests/05_test_error_handling.spec.c
+++ b/get_next_line_tests/tests/05_test_error_handling.spec.c
@@ -14,6 +14,10 @@ static void simple_string(t_test *test)
 
 	/* Not opened fd */
 	mt_assert(get_next_line(42, &line) == -1);
+
+	/* Too large fd */
+	mt_assert(get_next_line(10000000, NULL) == -1);
+	mt_assert(get_next_line(10000000, &line) == -1);
 }
 
 void	suite_05_test_error_handling(t_suite *suite)


### PR DESCRIPTION
According on Moulinitte tests we have to handle very large file descriptor on get_next_line.